### PR TITLE
do not log an incorrect backend host

### DIFF
--- a/middlewares/logger.go
+++ b/middlewares/logger.go
@@ -54,6 +54,7 @@ type combinedLoggingHandler struct {
 func (h combinedLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	t := time.Now()
 	context.Set(req, "frontendName", "Unknown frontend")
+	context.Set(req, "backendHost", "Unknown backend")
 	logger := &responseLogger{w: w}
 	h.handler.ServeHTTP(logger, req)
 
@@ -79,10 +80,11 @@ func (h combinedLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	referer := req.Referer()
 	agent := req.UserAgent()
 	frontendName := context.Get(req, "frontendName")
-	backendHost := req.RemoteAddr // FIXME TODO  this is not quite correct
+	//	backendHost := context.Get(req, "backendHost")  // not working yet
+	backendHost := "Unknown backend"
 	elapsed := time.Now().UTC().Sub(t.UTC())
 
-	fmt.Fprintf(h.writer, `%s - %s [%s] "%s %s %s" %d %d "%s" "%s" "%s" "%s" %s %s`,
+	fmt.Fprintf(h.writer, `%s - %s [%s] "%s %s %s" %d %d "%s" "%s" "%s" "%s" %s%s`,
 		host, username, ts, method, uri, proto, status, len, referer, agent, frontendName, backendHost, elapsed, "\n")
 
 	context.Clear(req)

--- a/server.go
+++ b/server.go
@@ -328,7 +328,7 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 				}
 				newRoute := serverEntryPoints[entryPointName].httpRouter.NewRoute().Name(frontendName)
 				for routeName, route := range frontend.Routes {
-					log.Debugf("Creating route %s %s:%s", routeName, route.Rule, route.Value)
+					log.Debugf("Creating route %s %s: %s", routeName, route.Rule, route.Value)
 					newRouteReflect, err := invoke(newRoute, route.Rule, route.Value)
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
Log "Unknown backend" for the backend host as a placeholder, rather than request.RemoteAddr.