### PR TITLE
Map URL to backend name

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/emilevauge/traefik/middlewares"
-	"github.com/emilevauge/traefik/provider"
+	"github.com/CiscoCloud/traefik/middlewares"
+	"github.com/CiscoCloud/traefik/provider"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"net/http"

--- a/configuration.go
+++ b/configuration.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/emilevauge/traefik/provider"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/provider"
+	"github.com/CiscoCloud/traefik/types"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 )

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
-	"github.com/emilevauge/traefik/integration/utils"
+	"github.com/CiscoCloud/traefik/integration/utils"
 
 	checker "github.com/vdemeester/shakers"
 	check "gopkg.in/check.v1"

--- a/middlewares/logger.go
+++ b/middlewares/logger.go
@@ -1,8 +1,10 @@
 package middlewares
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -53,6 +55,9 @@ type combinedLoggingHandler struct {
 
 func (h combinedLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer context.Clear(req)
+	var url2backend map[string]string
+	b, _ := ioutil.ReadFile("url2backend.json")
+	json.Unmarshal(b, &url2backend)
 
 	t_start := time.Now()
 	context.Set(req, "frontend", "Unknown frontend")
@@ -82,7 +87,7 @@ func (h combinedLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	referer := req.Referer()
 	agent := req.UserAgent()
 	frontend := context.Get(req, "frontend")
-	backend := context.Get(req, "oxy_backend")
+	backend := url2backend[fmt.Sprintf("%s", context.Get(req, "oxy_backend"))]
 	elapsed := time.Now().UTC().Sub(t_start.UTC())
 
 	fmt.Fprintf(h.writer, `%s - %s [%s] "%s %s %s" %d %d "%s" "%s" "%s" "%s" %s%s`,

--- a/provider/boltdb.go
+++ b/provider/boltdb.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 )
 
 // BoltDb holds configurations of the BoltDb provider.

--- a/provider/consul.go
+++ b/provider/consul.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 )
 
 // Consul holds configurations of the Consul provider.

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -11,7 +11,7 @@ import (
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/provider/docker_test.go
+++ b/provider/docker_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 	"github.com/fsouza/go-dockerclient"
 )
 

--- a/provider/etcd.go
+++ b/provider/etcd.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/etcd"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 )
 
 // Etcd holds configurations of the Etcd provider.

--- a/provider/file.go
+++ b/provider/file.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 	"gopkg.in/fsnotify.v1"
 )
 

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 )
 
 // Kv holds common configurations of key-value providers.

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -9,11 +9,9 @@ import (
 	"strings"
 	"text/template"
 
-	"net/http"
-
 	"github.com/BurntSushi/ty/fun"
+	"github.com/CiscoCloud/traefik/types"
 	log "github.com/Sirupsen/logrus"
-	"github.com/emilevauge/traefik/types"
 	"github.com/gambol99/go-marathon"
 )
 

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"errors"
-	"github.com/emilevauge/traefik/mocks"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/mocks"
+	"github.com/CiscoCloud/traefik/types"
 	"github.com/gambol99/go-marathon"
 	"github.com/stretchr/testify/mock"
 )

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -7,8 +7,8 @@ import (
 	"text/template"
 
 	"github.com/BurntSushi/toml"
-	"github.com/emilevauge/traefik/autogen"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/autogen"
+	"github.com/CiscoCloud/traefik/types"
 )
 
 // Provider defines methods of a provider.

--- a/provider/zk.go
+++ b/provider/zk.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/zookeeper"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/types"
 )
 
 // Zookepper holds configurations of the Zookepper provider.

--- a/server.go
+++ b/server.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,11 +17,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/CiscoCloud/traefik/middlewares"
+	"github.com/CiscoCloud/traefik/provider"
+	"github.com/CiscoCloud/traefik/types"
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/negroni"
-	"github.com/emilevauge/traefik/middlewares"
-	"github.com/emilevauge/traefik/provider"
-	"github.com/emilevauge/traefik/types"
 	"github.com/gorilla/mux"
 	"github.com/mailgun/manners"
 	"github.com/mailgun/oxy/cbreaker"
@@ -125,8 +124,6 @@ func (server *Server) listenProviders() {
 func (server *Server) listenConfigurations() {
 	for {
 		configMsg := <-server.configurationValidatedChan
-		fmt.Printf("debug... configMsg: %#+v\n", configMsg)
-		fmt.Printf("debug... configuration: %#+v\n", configMsg.Configuration)
 		if configMsg.Configuration == nil {
 			log.Infof("Skipping empty Configuration for provider %s", configMsg.ProviderName)
 		} else if reflect.DeepEqual(server.currentConfigurations[configMsg.ProviderName], configMsg.Configuration) {

--- a/web.go
+++ b/web.go
@@ -8,8 +8,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/elazarl/go-bindata-assetfs"
-	"github.com/emilevauge/traefik/autogen"
-	"github.com/emilevauge/traefik/types"
+	"github.com/CiscoCloud/traefik/autogen"
+	"github.com/CiscoCloud/traefik/types"
 	"github.com/gorilla/mux"
 	"github.com/thoas/stats"
 	"github.com/unrolled/render"


### PR DESCRIPTION
The main thrust of these changes is to log the backend name, not the backend URL.  The url2backend map is currently passed to the middleware logger via a file.  This is a hack, and a better way needs to be found.  But at least it works and demonstrates how to map the URL to backend name.